### PR TITLE
fix: resolve build and documentation failures on main

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -9,7 +9,7 @@ public_url = "/"
 
 [watch]
 # Watch these paths for changes
-watch = ["game-runner/src", "game-physics/src", "game-units/src", "game-world/src", "game-ai/src", "game-combat/src", "game-assets/src"]
+watch = ["game-runner/src", "game-physics/src", "game-units/src", "game-world/src", "game-ai/src", "game-combat/src", "game-assets/src", "game-audio/src", "game-ui/src"]
 ignore = ["target", "dist"]
 
 [serve]

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Cosmic Cults RTS</title>
+    <link rel="rust" href="game-runner/Cargo.toml" />
     <style>body { margin: 0; overflow: hidden; background-color: black; }</style>
   </head>
   <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ docs = [
     "sphinx>=7.0.0",
     "sphinx-rtd-theme>=1.0.0",
     "myst-parser>=1.0.0",
+    "sphinx-autodoc-typehints>=1.22.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Addressing WASM build and documentation deployment errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses build and docs issues by aligning Trunk, HTML entrypoint, and docs deps.
> 
> - Expands Trunk `watch` to include `game-audio/src` and `game-ui/src`
> - Adds `<link rel="rust" href="game-runner/Cargo.toml" />` to `index.html` to ensure Trunk locates the Rust workspace entrypoint
> - Adds `sphinx-autodoc-typehints` to `docs` optional dependencies in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6c9683ff6c8f982db979543ecc37140a2f47b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->